### PR TITLE
Hide archived alters

### DIFF
--- a/routes/system.js
+++ b/routes/system.js
@@ -682,7 +682,6 @@ router.get("/:id/:pg?",
   authUser,
   validateParam("id"),
   async (req, res, next) => {
-    console.log(req.query);
     const display_archive = req.query.display_archive ?? "false";
     if (!req.session.worksheets_enabled) {
       // Quick, add that.
@@ -809,23 +808,24 @@ router.get("/:id/:pg?",
       });
     });
     const altCount = total_alters[0].count;
+    const resCount = alters.length;
     req.session.alters.sort((a, b) => a.name.localeCompare(b.name));
     req.session.alters = paginate(
       req.session.alters,
       Number(numUp[0].altupnum)
     );
-    const cp = (req.params.pg > req.session.alters.length) ? req.session.alters.length : (req.params.pg || 1);
-    console.log(`req.params.pg: ${req.params.pg}, req.session.alters.length: ${req.session.alters.length}, cp: ${cp}`);
+    /* Don't go past the end of the pages. */
+    const curPage = (req.params.pg > req.session.alters.length) ? req.session.alters.length : (req.params.pg || 1);
     res.render(`pages/sys_info`, {
       session: req.session,
-      alterArr: req.session.alters[req.params.pg - 1 || 0],
+      alterArr: req.session.alters[curPage - 1 || 0],
       cookies: req.cookies,
       query: req.query,
       sys_id: req.params.id,
       pgCount: req.session.alters.length,
       altCount,
-      /* Don't go past the end of the pages. */
-      curPage: (req.params.pg > req.session.alters.length) ? req.session.alters.length : (req.params.pg || 1),
+      resCount,
+      curPage,
       numup: Number(numUp[0].altupnum),
       currentSys: req.params.id,
       environment: config.ENVIRONMENT

--- a/routes/system.js
+++ b/routes/system.js
@@ -682,6 +682,8 @@ router.get("/:id/:pg?",
   authUser,
   validateParam("id"),
   async (req, res, next) => {
+    console.log(req.query);
+    const display_archive = req.query.display_archive ?? "false";
     if (!req.session.worksheets_enabled) {
       // Quick, add that.
       const wsEn = await db.query(
@@ -734,9 +736,54 @@ router.get("/:id/:pg?",
       req
     );
 
+    let archive_select = "AND alters.is_archived = FALSE";
+    if (display_archive === "only") {
+      archive_select = "AND alters.is_archived = TRUE";
+    } else if (display_archive === "true") {
+      archive_select = "";
+    }
+    const total_alters = await db.query(client,
+      ` SELECT COUNT(1) AS count
+        FROM alters
+        WHERE alters.sys_id = $1
+          OR (alters.subsys_id1 = $1::text
+          OR alters.subsys_id2 = $1::text
+          OR alters.subsys_id3 = $1::text
+          OR alters.subsys_id4 = $1::text
+          OR alters.subsys_id5 = $1::text
+        )`,
+      [`${req.params.id}`],
+      res,
+      req
+    );
+    req.session.total_alters = total_alters[0].count;
     const alters = await db.query(
       client,
-      "SELECT alters.alt_id, alters.img_url, alters.sys_id, alters.name, alters.pronouns, alter_moods.mood, alters.is_archived, alters.img_blob, alters.blob_mimetype, alters.colour, alters.colour_enabled, alters.outline_enabled, alters.outline FROM alters LEFT JOIN alter_moods ON alters.alt_id = alter_moods.alt_id WHERE alters.sys_id = $1 OR (alters.subsys_id1 = $1::text OR alters.subsys_id2 = $1::text OR alters.subsys_id3 = $1::text OR alters.subsys_id4 = $1::text OR alters.subsys_id5 = $1::text) ORDER BY alters.name ASC;",
+      ` SELECT
+          alters.alt_id,
+          alters.img_url,
+          alters.sys_id,
+          alters.name,
+          alters.pronouns,
+          alter_moods.mood,
+          alters.is_archived,
+          alters.img_blob,
+          alters.blob_mimetype,
+          alters.colour,
+          alters.colour_enabled,
+          alters.outline_enabled,
+          alters.outline
+        FROM alters
+        LEFT JOIN alter_moods ON alters.alt_id = alter_moods.alt_id
+        WHERE alters.sys_id = $1
+          ${archive_select}
+          OR (alters.subsys_id1 = $1::text
+            OR alters.subsys_id2 = $1::text
+            OR alters.subsys_id3 = $1::text
+            OR alters.subsys_id4 = $1::text
+            OR alters.subsys_id5 = $1::text
+          )
+        ORDER BY alters.name ASC;`,
       [`${req.params.id}`],
       res,
       req
@@ -761,20 +808,24 @@ router.get("/:id/:pg?",
         outline: alter.outline,
       });
     });
-    const altCount = req.session.alters.length;
+    const altCount = total_alters[0].count;
     req.session.alters.sort((a, b) => a.name.localeCompare(b.name));
     req.session.alters = paginate(
       req.session.alters,
       Number(numUp[0].altupnum)
     );
+    const cp = (req.params.pg > req.session.alters.length) ? req.session.alters.length : (req.params.pg || 1);
+    console.log(`req.params.pg: ${req.params.pg}, req.session.alters.length: ${req.session.alters.length}, cp: ${cp}`);
     res.render(`pages/sys_info`, {
       session: req.session,
       alterArr: req.session.alters[req.params.pg - 1 || 0],
       cookies: req.cookies,
+      query: req.query,
       sys_id: req.params.id,
       pgCount: req.session.alters.length,
       altCount,
-      curPage: req.params.pg || 1,
+      /* Don't go past the end of the pages. */
+      curPage: (req.params.pg > req.session.alters.length) ? req.session.alters.length : (req.params.pg || 1),
       numup: Number(numUp[0].altupnum),
       currentSys: req.params.id,
       environment: config.ENVIRONMENT

--- a/routes/systemdata.js
+++ b/routes/systemdata.js
@@ -573,7 +573,7 @@ router.put("/system-data", async function (req, res) {
 			} else if (editMode == "add-ph-alter") {
 				// Place placeholder alters in database.
 				let iconNo =
-					`${config.URL_PREFIX}/` + getRandomInt(1, 42) + ".png";
+					`${config.URL_PREFIX}/img/` + getRandomInt(1, 42) + ".png";
 				client.query(
 					{
 						text: "INSERT INTO alters (name, sys_id, img_url, gender) VALUES($1, $2, $3, $4);",

--- a/views/pages/sys_info.ejs
+++ b/views/pages/sys_info.ejs
@@ -52,7 +52,10 @@ var journSkin=[
     {name: "Trident", file: "trident"},
     {name: "Message in a Bottle", file: "bottle"},
     {name: "Beach", file: "island"},
-]
+];
+let queryString = new URLSearchParams(query).toString();
+queryString = queryString ? `?${queryString}` : "";
+console.log(`queryString: ${queryString}`);
     %>
     <div id="wrapper">
         <% if (environment == "dev"){ %>
@@ -80,44 +83,47 @@ var journSkin=[
                 </div>
             <% } %>
             
-            
             <div id="pagination" class="pageJump">
                 <ul>
-                    <% if (curPage > 1){ %><li><i class="fa fa-arrow-left" aria-hidden="true"></i> <a href="/system/<%= session.chosenSys.sys_id %>/<%= parseInt(curPage) - 1 %>">Previous</a></li><% } %>
+                    <% if (curPage > 1){ %><li><i class="fa fa-arrow-left" aria-hidden="true"></i> <a href="/system/<%= session.chosenSys.sys_id %>/<%= parseInt(curPage) - 1 %><%= queryString %>">Previous</a></li><% } %>
                   <li class="currPage"><%= curPage %></li>
-                  <% if (curPage < pgCount){ %><li><a href="/system/<%= session.chosenSys.sys_id %>/<%= parseInt(curPage) + 1 %>">Next <i class="fa fa-arrow-right" aria-hidden="true"></i></a></li>
-                  <li><a href="/system/<%= session.chosenSys.sys_id %>/<%= parseInt(pgCount) %>">Last (<%= parseInt(pgCount) %>) <i class="fa fa-arrow-right" aria-hidden="true"></i></a></li>
+                  <% if (curPage < pgCount){ %><li><a href="/system/<%= session.chosenSys.sys_id %>/<%= parseInt(curPage) + 1 %><%= queryString %>">Next <i class="fa fa-arrow-right" aria-hidden="true"></i></a></li>
+                  <li><a href="/system/<%= session.chosenSys.sys_id %>/<%= parseInt(pgCount) %><%= queryString %>">Last (<%= parseInt(pgCount) %>) <i class="fa fa-arrow-right" aria-hidden="true"></i></a></li>
                   <% } %>
                   </ul>
                   <form method="none">
-                  <label for="page">Go to page: </label><input type="number" min="1" max="<%= pgCount %>" name="page" id="page" style="width: 3em;">
+                  <label for="page">Go to page: </label><input type="number" min="1" max="<%= pgCount %>" name="page" id="page" style="width: 3em;" value="<%= curPage %>">
                   <button id="go">Go</button>
                   </form>
+                  <label for="display_archived">Show archived <%= pluralize(cookies.alter_term) %>:</label>
+                  <select onchange="window.location.href = updateQuery({display_archive: this.value})" name="display_archived" id="display_archived">
+                      <option value="false" <%- query.display_archive === "false" ? "selected" : "" %> >No</option>
+                      <option value="true" <%- query.display_archive === "true" ? "selected" : "" %> >Yes</option>
+                      <option value="only" <%- query.display_archive === "only" ? "selected" : "" %> >Only</option>
+                  </select>
                 </div>
                 <a class="dyn linkbutton" title="<%= siteLanguage[session.language || "en"].comm %>" href="/system/communal-journal?sys=<%= session.chosenSys.sys_id %>"><%= siteLanguage[session.language || "en"].comm %></a>
             <% if (parseInt(altCount) > 0){ %>
                 <a class="linkbutton" href="/search"><i class="fa fa-search"></i> <%= capitalise(cookies.alter_term) %> Search</a>
                 <p><%= capitalise(pluralize(cookies.alter_term)) %>: <strong><%= parseInt(altCount).toLocaleString() %></strong></p>
-                <p class="dyn">Showing you <%= numup %> [[ALTERS]] per page. [[ALTERSCAP]] marked with a ✦ have their primary [[SYSTEM]] listed differently.</p>
+                <p class="dyn">Showing you <%= numup %> [[A<%= query.display_archve === "false" ? "selected" : "" %>LTERS]] per page. [[ALTERSCAP]] marked with a ✦ have their primary [[SYSTEM]] listed differently.</p>
 
-            
             <div class="grid" id="sysContainer">
                 <% for ( i in alterArr) {
-                    if (alterArr[i].is_archived== false){
                     %>
                     <a href="/alter/<%= alterArr[i].a_id %>" style="text-decoration: none;">
-                        <div class="polaroid child" >
+                        <div class="polaroid <%- alterArr[i].is_archived ? "archived" : "" %> child">
                         <% if (alterArr[i].img_blob){ %> 
-                            <img class="smallimg"src="data:<%= alterArr[i].blob_mimetype %>;base64,<%= Buffer.from(alterArr[i].img_blob).toString("base64") %>"> 
+                            <img class="smallimg" src="data:<%= alterArr[i].blob_mimetype %>;base64,<%= Buffer.from(alterArr[i].img_blob).toString("base64") %>"> 
                             <% } else if (distill(alterArr[i].icon)) { %>
                             <img src="<%= Buffer.from(alterArr[i].icon, 'base64').toString() %>" class="smallimg">
                         <% } else { %> 
                             <img src="https://i.ibb.co/vkwmWjF/avatar-default.jpg" class="smallimg" alt="Card Icon">
                         <% } %>
-                     <br>
-                    
+                    <br/>
                     <span
-                    style="
+                    <% if (alterArr[i].is_archived== false) { %>
+                      style="
                         <% if(alterArr[i].colourEnabled==true){ %>
                             color: <%- alterArr[i].colour %>;
                         <% } %>
@@ -128,42 +134,16 @@ var journSkin=[
                                         1px 1px 0 <%- alterArr[i].outline %>;
                         <% } %>
                         "
+                    <% } %>
                         ><%= truncate(boil(alterArr[i].name), 13) %></span> 
                     <% if (alterArr[i].id !== currentSys){ %>✦<% } %>
-                     <% if (alterArr[i].mood) { %><%- moods[alterArr[i].mood].emoji %><% } %>
-                     <% if (alterArr[i].pronouns){ %> 
+                    <% if (alterArr[i].mood) { %><%- moods[alterArr[i].mood].emoji %><% } %>
+                    <% if (alterArr[i].pronouns){ %> 
                         <% if (distill(alterArr[i].pronouns)){ %><br><small><%= truncate(boil(Buffer.from(alterArr[i].pronouns, "base64").toString()), 16) %></small>
                         <% } %> 
-                        <% } %>
-
-                     
-                        
-                    </div></a> 
-                    
-                <% }} %>
-                <% for ( i in alterArr) {  
-                    if (alterArr[i].is_archived== true){
-                    %>
-                    <a href="/alter/<%= alterArr[i].a_id %>" style="text-decoration: none;"><div class="polaroid archived child">
-                        <% if (alterArr[i].img_blob){ %> 
-                            <img class="smallimg" src="data:<%= alterArr[i].blob_mimetype %>;base64,<%= Buffer.from(alterArr[i].img_blob).toString("base64") %>"> 
-                            
-                            <% } else if (distill(alterArr[i].icon)) { %>
-                            <img src="<%= Buffer.from(alterArr[i].icon, 'base64').toString() %>" class="smallimg">
-                        <% } else { %> 
-                            <img src="https://i.ibb.co/vkwmWjF/avatar-default.jpg" class="smallimg" alt="Card Icon">
-                        <% } %>
-                        <br>
-                        <%= truncate(boil(alterArr[i].name), 13) %> 
-                        <% if (alterArr[i].mood) { %><%- moods[alterArr[i].mood].emoji %><% } %>
-                        <% if (alterArr[i].pronouns){ %>
-                            <% if (distill(alterArr[i].pronouns)){ %>
-                                <br><small><%- truncate(boil(Buffer.from(alterArr[i].pronouns, "base64").toString()), 32) %></small>
-                                <% } %>
-                                <% } %>
+                    <% } %>
                     </div></a>
-                    
-                <% }} %>
+                <% } %>
             </div>
             <% } %>
         
@@ -309,13 +289,19 @@ var journSkin=[
         }
         $("#go").on("click", function(){
           event.preventDefault();
-          window.location= `/system/<%= session.chosenSys.sys_id %>/${$("#page").val()}`
+          window.location= `/system/<%= session.chosenSys.sys_id %>/${$("#page").val()}<%= queryString %>`
         })
         if (parseInt(<%= pgCount %>) <= 1){
             $("#pagination").hide()
         }
 
-
+        function updateQuery(updatedParams) {
+            const params = new URLSearchParams(window.location.search);
+            for (const key in updatedParams) {
+                params.set(key, updatedParams[key]);
+            }
+            return `${window.location.pathname}?` + params.toString();
+        }
     
     </script>
 </body>

--- a/views/pages/sys_info.ejs
+++ b/views/pages/sys_info.ejs
@@ -55,7 +55,6 @@ var journSkin=[
 ];
 let queryString = new URLSearchParams(query).toString();
 queryString = queryString ? `?${queryString}` : "";
-console.log(`queryString: ${queryString}`);
     %>
     <div id="wrapper">
         <% if (environment == "dev"){ %>

--- a/views/pages/sys_info.ejs
+++ b/views/pages/sys_info.ejs
@@ -95,18 +95,20 @@ console.log(`queryString: ${queryString}`);
                   <label for="page">Go to page: </label><input type="number" min="1" max="<%= pgCount %>" name="page" id="page" style="width: 3em;" value="<%= curPage %>">
                   <button id="go">Go</button>
                   </form>
-                  <label for="display_archived">Show archived <%= pluralize(cookies.alter_term) %>:</label>
-                  <select onchange="window.location.href = updateQuery({display_archive: this.value})" name="display_archived" id="display_archived">
-                      <option value="false" <%- query.display_archive === "false" ? "selected" : "" %> >No</option>
-                      <option value="true" <%- query.display_archive === "true" ? "selected" : "" %> >Yes</option>
-                      <option value="only" <%- query.display_archive === "only" ? "selected" : "" %> >Only</option>
-                  </select>
                 </div>
                 <a class="dyn linkbutton" title="<%= siteLanguage[session.language || "en"].comm %>" href="/system/communal-journal?sys=<%= session.chosenSys.sys_id %>"><%= siteLanguage[session.language || "en"].comm %></a>
             <% if (parseInt(altCount) > 0){ %>
                 <a class="linkbutton" href="/search"><i class="fa fa-search"></i> <%= capitalise(cookies.alter_term) %> Search</a>
-                <p><%= capitalise(pluralize(cookies.alter_term)) %>: <strong><%= parseInt(altCount).toLocaleString() %></strong></p>
-                <p class="dyn">Showing you <%= numup %> [[A<%= query.display_archve === "false" ? "selected" : "" %>LTERS]] per page. [[ALTERSCAP]] marked with a ✦ have their primary [[SYSTEM]] listed differently.</p>
+                <p>
+                    <label for="display_archived">Show archived <%= pluralize(cookies.alter_term) %>:</label>
+                    <select onchange="window.location.href = updateQuery({display_archive: this.value})" name="display_archived" id="display_archived" class="linkbutton">
+                        <option value="false" <%- query.display_archive === "false" ? "selected" : "" %> >No</option>
+                        <option value="true" <%- query.display_archive === "true" ? "selected" : "" %> >Yes</option>
+                        <option value="only" <%- query.display_archive === "only" ? "selected" : "" %> >Only</option>
+                    </select>
+                    <strong><%= parseInt(resCount).toLocaleString() %></strong> of <strong><%= parseInt(altCount).toLocaleString() %></strong> <%= pluralize(cookies.alter_term) %> listed.
+                </p>
+                <p class="dyn">Showing you <%= numup %> [[ALTERS]] per page. [[ALTERSCAP]] marked with a ✦ have their primary [[SYSTEM]] listed differently.</p>
 
             <div class="grid" id="sysContainer">
                 <% for ( i in alterArr) {


### PR DESCRIPTION
# Hide Archived Alters

> Please use this template when submitting a pull request. It makes reviewing your code much easier and faster, which means your contribution can be merged in faster! Feel free to delete this section and the instructions before submitting your pull request, but please keep the checkbox at the end.


## Description

I have been asked to make a change to allow archived alters to be hidden. I notice you made a change which sorts archived alters to the end of the list. The person I am working with would still like to be able to hide archived alters, so I hope you still consider this change to be useful.

Notice that while the SQL is changed to a template string, there are only three possible SQL statements it creates. If the query string is set to something unexpected, the default SQL is run (hiding archived alters). I don't think there is any way to mess things up by adding weird query strings. HTML characters are escaped by the browser, I don't think javascript can be injected.

I did fix a minor bug in `routes/systemdata.ejs` to set the path for the image correctly when adding test alters in dev mode.

## Optional Checkboxes

- [ ] I would like to join Team Crystalline Organisation on GitHub.
- [ ] I would like the Developer role in the Lighthouse Discord server. (We'll ask you for your Discord username in the comments and assign the role after your pull request is merged in.)

## Required Checkboxes

- [ ] If my changes affected the database, I have discussed this with EscapeToTheCity first. (You can leave this one unchecked if your changes did not affect the database.)
- [x] I have read the CONTRIBUTING.md file and followed the instructions for contributing to the project.
- [x] I have guerilla tested my code to the best of my ability and am confident that it works as intended.
- [x] I have not used an AI code generator to write this code.
