### PR TITLE
Hide archived quickfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lighthouse",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "A journal app for systems to write diaries. Plural users specifically.",
   "main": "main.js",
   "scripts": {

--- a/routes/system.js
+++ b/routes/system.js
@@ -781,7 +781,7 @@ router.get("/:id/:pg?",
             OR alters.subsys_id3 = $1::text
             OR alters.subsys_id4 = $1::text
             OR alters.subsys_id5 = $1::text
-          )
+          ) ${archive_select}
         ORDER BY alters.name ASC;`,
       [`${req.params.id}`],
       res,

--- a/views/pages/sys_info.ejs
+++ b/views/pages/sys_info.ejs
@@ -110,7 +110,7 @@ queryString = queryString ? `?${queryString}` : "";
                     <strong><%= parseInt(resCount).toLocaleString() %></strong> of <strong><%= parseInt(altCount).toLocaleString() %></strong> <%= pluralize(cookies.alter_term) %> listed.
                 </p>
                 <p class="dyn">Showing you <%= numup %> [[ALTERS]] per page. [[ALTERSCAP]] marked with a ✦ have their primary [[SYSTEM]] listed differently.</p>
-
+                
             <div class="grid" id="sysContainer">
                 <% for ( i in alterArr) {
                     %>


### PR DESCRIPTION
# Hide Archived Members - Quick fix

## Description

Includes neighbouring members (members in multiple systems) in the "hide archived" filter.

### Expected Behaviour

All members filter based on the "hide archived" drop down.

### Actual Behaviour

All members filter, but neighbouring members would not get filtered because SQL can get funky.

### Reproduction Steps

Add a member to multiple systems, then show only archived members. The neighbouring members should still appear.

## Required Checkboxes

- [ ] If my changes affected the database, I have discussed this with EscapeToTheCity first. (You can leave this one unchecked if your changes did not affect the database.)
- [x] I have read the CONTRIBUTING.md file and followed the instructions for contributing to the project.
- [x] I have guerilla tested my code to the best of my ability and am confident that it works as intended.
- [x] I have not used an AI code generator to write this code.
